### PR TITLE
Removed inline from non-inline function declaration

### DIFF
--- a/src/input/libastar/astar_heap.h
+++ b/src/input/libastar/astar_heap.h
@@ -101,7 +101,7 @@ asheap_t * astar_heap_new (uint32_t initial_length, uint32_t delta);
 void astar_heap_destroy (asheap_t * heap);
 
 
-inline void astar_heap_clear (asheap_t * heap);
+void astar_heap_clear (asheap_t * heap);
 
 
 uint32_t astar_heap_sizeof (asheap_t * heap);


### PR DESCRIPTION
With the current makefile setting -Werror, the function astar_heap_clear being declared inline but not defined inline will keep the code from building.