### PR TITLE
Update to GLFW 3 so that it builds on modern systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 CC = gcc
 
 CFLAGS = -Isrc $(LIB_INCLUDE_PATH) -Wall -Wextra -Werror -g
-LIB_DEPS = $(LIB_BIN_PATH) $(GL_LIBS)
+LIB_DEPS = $(LIB_BIN_PATH) $(GL_LIBS) -lm
 
 BUILD_DIR = build
 OBJ_DIR = build/obj

--- a/README
+++ b/README
@@ -6,6 +6,11 @@
 
 An aquatic roguelike by Jonathan Whiting.
 
+This version of Sunk Coast is a port to GLFW 3 so that
+it can build on modern systems.
+
+------------------------------------------------------
+
 You're flat broke. Legends tell of priceless golden
 doubloons sunk two hundred fathoms deep. You promised
 not to do anything stupid, but then again your family
@@ -24,8 +29,8 @@ Executables:
   Windows executable: sunkcoast.exe
     Linux executable: sunkcoast
   If you are using the linux build you must have glfw
-  and DevIL runtimes installed. On ubuntu I believe the
-  packages are 'libglfw2' and 'libdevil1c2'.
+  and DevIL runtimes installed. On ubuntu the packages
+  are 'libglfw3' and 'libdevil1c2'.
 
 Get in touch:
   Website: http://jonathanwhiting.com

--- a/src/game/item.c
+++ b/src/game/item.c
@@ -52,13 +52,13 @@ int item_value(ItemType type, ItemSubtype subtype)
   int out = 0;
   switch(subtype)
   {
-    case IST_INKY: out = 2;
-    case IST_AZURE: out = 15;
-    case IST_PEARL: out = 20;
-    case IST_SEAWEED: out = 1;
-    case IST_BARNACLED: out = 10;
-    case IST_GOLDEN: out = 100;
-    case IST_CORAL: out = 5;
+    case IST_INKY: out = 2; break;
+    case IST_AZURE: out = 15; break;
+    case IST_PEARL: out = 20; break;
+    case IST_SEAWEED: out = 1; break;
+    case IST_BARNACLED: out = 10; break;
+    case IST_GOLDEN: out = 100; break;
+    case IST_CORAL: out = 5; break;
     default: out = 1;
   }
   if(type == IT_DOUBLOON)

--- a/src/main.h
+++ b/src/main.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <time.h>
 
-#include <GL/glfw.h>
+#include <GLFW/glfw3.h>
 #include <IL/il.h> 
 
 #include "datatypes.h"

--- a/src/sys/sys.c
+++ b/src/sys/sys.c
@@ -46,6 +46,7 @@ void sys_init(Point resolution, int pixel_scale)
     LOG("Failed to create GLFW window");
     exit( EXIT_FAILURE );
   }
+  glfwMakeContextCurrent( _window );
   
   // Detect key presses between calls to GetKey
   glfwSetInputMode( _window, GLFW_STICKY_KEYS, GLFW_TRUE );
@@ -167,6 +168,7 @@ void sys_drawFinish()
   _sys_drawRectangle(rectWBar, black);
   
   glfwSwapBuffers( _window );
+  glfwPollEvents();
 }
 
 ImageID sys_loadImage(const char *name)


### PR DESCRIPTION
The last version of Ubuntu to ship with GLFW 2 is 16.04. Meanwhile, 16.04 and later support GLFW 3. This change updates Sunk Coast to use GLFW 3 so that it can compile on recent Ubuntu releases.