### PR TITLE
Fix _resolution globality

### DIFF
--- a/src/sys/sys.c
+++ b/src/sys/sys.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 GLFWwindow *_window;
-Point _resolution;
+static Point _resolution;
 Point _windowSize;
 int _pixel_scale;
 Rectangle _drawRect;


### PR DESCRIPTION
Hello! I've tried to compile your game and linker seems to have troubles with _resolution:

```
[parthen@parthen-pc SunkCoast]$ make
mkdir -p build/out/
gcc build/obj/datatypes.o build/obj/main.o build/obj/game/game.o build/obj/game/item.o build/obj/game/spawn.o build/obj/input/libastar/astar.o build/obj/input/libastar/astar_heap.o build/obj/input/libfov/fov.o build/obj/sys/file.o build/obj/sys/logging.o build/obj/sys/sys.o build/obj/world/feature.o build/obj/world/tilemap.o  -lGL -lGLU -lIL -lglfw -lm -o build/out/sunkcoast
/usr/bin/ld: build/obj/sys/sys.o:/home/parthen/Projects/SunkCoast/src/sys/sys.c:5: multiple definition of `_resolution'; build/obj/main.o:/home/parthen/Projects/SunkCoast/src/main.c:11: first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:67: build/out/sunkcoast] Error 1

```

Making _resolution static fixed it